### PR TITLE
Correct typo in payroll deduction section

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
         <h3>Get your employer to match your donation</h3>
         <p>Many freeCodeCamp supporters are able to get their employers to match their donations to freeCodeCamp. Our Tax-exempt number (EIN) is 82-0779546. If we can help you with setting this up, please email <a href="mailto:team@freecodecamp.org">team@freecodecamp.org</a>.</p>
         <hr>        
-        <h3>Donate through a payroll decduction</h3>
+        <h3>Donate through a payroll deduction</h3>
         <p>In the US and Canada, some employers have a convenient way to give to freeCodeCamp through a payroll deduction. Ask your employer if they can do this, and have them send any necessary paperwork to:</p>
         <p>Free Code Camp, Inc.<br>7800 W Hefner Rd, PO BOX 721024<br>Oklahoma City, Oklahoma 73172<br>United States</p>
         <hr>


### PR DESCRIPTION
The word "deduction" was misspelled in the payroll deduction section of the page.